### PR TITLE
feature(gateway): support tail match

### DIFF
--- a/onyxia-gateway/src/main.rs
+++ b/onyxia-gateway/src/main.rs
@@ -107,8 +107,8 @@ fn main() -> std::io::Result<()> {
             .data(Cell::new(0usize))
             .wrap(middleware::Logger::default())
             .service(
-                // FIXME: can not represent the path who has a slash
-                web::resource("/{path}")
+                // https://actix.rs/docs/url-dispatch/
+                web::resource("/{path:.*}")
                     .route(web::get().to(index))
                     .route(web::post().to_async(upload)),
             )


### PR DESCRIPTION
[actix router](https://actix.rs/docs/url-dispatch/)
```
POST /path/to/some/files -> path = 'path/to/some/files '
```